### PR TITLE
Change taskbar to allign/justify left by default.

### DIFF
--- a/Startup Scripts/SandboxStartup.ps1
+++ b/Startup Scripts/SandboxStartup.ps1
@@ -19,6 +19,9 @@ if ($env:USERNAME -ne "WDAGUtilityAccount") {
 # Change context menu to old style
 reg.exe add "HKCU\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32" /f /ve
 
+# Change taskbar to allign left
+reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarAl" /t REG_DWORD /d 0 /f
+
 # Show file extensions
 reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "HideFileExt" /t REG_DWORD /d 0 /f
 


### PR DESCRIPTION
This isn't strictly a necessary change but I have it added on my local usage so figured I should contribute it, It makes the taskbar justify left as it did by default in windows 10.

The registry stored at `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\TaskbarAl` is never read on windows 10 so adding it shouldn't cause any problems even when used on windows 10.