### PR TITLE
chore: update default wsb to include better samples

### DIFF
--- a/Sandbox Configurations/MyDefaultSandbox.wsb
+++ b/Sandbox Configurations/MyDefaultSandbox.wsb
@@ -28,9 +28,12 @@
 	<!-- Run the powershell script from the mapped folder -->
 	<LogonCommand>
 		<!-- The seemingly redundant command nesting makes it so the powershell window is visible when running. -->
-		<Command>powershell -executionpolicy Bypass -command "start powershell {-file C:\Users\WDAGUtilityAccount\Desktop\HostShared\SandboxStartup.ps1 -launchingSandbox}"</Command>
+		<Command>powershell -executionpolicy Bypass -command "start powershell {-file C:\Users\WDAGUtilityAccount\Desktop\HostShared\Windows-Sandbox-Tools\General Scripts\SandboxStartup.ps1 -launchingSandbox}"</Command>
 		<!-- Note: You can add more powershell commands in additional blocks. For example you can uncomment the line below. -->
-		<!-- <Command>powershell -executionpolicy Bypass -command "start powershell {-file \"C:\Users\WDAGUtilityAccount\Desktop\HostShared\Set Theme Dark Mode.ps1\"}"</Command> -->
+		<!-- <Command>powershell -executionpolicy Bypass -command "start powershell {-file \"C:\Users\WDAGUtilityAccount\Desktop\HostShared\Windows-Sandbox-Tools\General Scripts\Set Theme Dark Mode.ps1\"}"</Command> -->
+		<!-- <Command>powershell -executionpolicy Bypass -command "start powershell {-file \"C:\Users\WDAGUtilityAccount\Desktop\HostShared\Windows-Sandbox-Tools\Installer Scripts\Install VC Redist.ps1\"}"</Command> -->
+		<!-- <Command>powershell -executionpolicy Bypass -command "start powershell {-file \"C:\Users\WDAGUtilityAccount\Desktop\HostShared\Windows-Sandbox-Tools\Installer Scripts\Install-Microsoft-Store.ps1\"}"</Command> -->
+		<!-- <Command>powershell -executionpolicy Bypass -command "start powershell {-file \"C:\Users\WDAGUtilityAccount\Desktop\HostShared\Windows-Sandbox-Tools\Installer Scripts\Install-Winget.ps1\"}"</Command> -->
 	</LogonCommand>
 
 </Configuration> 


### PR DESCRIPTION
Hi Thio,

Huge fan of your channel and saw this a while ago, I built something similar a longer time ago, even with arm support: 
https://github.com/CrazyWolf13/home-assets/blob/main/scripts-collection/better-sandbox/boot.ps1

Though your project is much more advanced, while setting this up on multiple machines I noticed, that not all scripts that are available are listed in the wsb config and also they are missing some subfolders as I guess most users will mount the root folder above the cloned `Windows-Sandbox-Tools` folder.

If those changes don't align feel free to close, I just thought I draft a PR if I change it anyway on all my hosts and it could save some others a bit of time :)