### PR TITLE
Fix for Expand-Archive failure in localized Sandbox environments

### DIFF
--- a/Installer Scripts/Install-Winget.ps1
+++ b/Installer Scripts/Install-Winget.ps1
@@ -81,6 +81,7 @@ function Install-WingetDependencies {
 $ProgressPreference = 'SilentlyContinue'
 
 $downloadPath = Join-Path $env:USERPROFILE "Downloads"
+if (!(Test-Path $downloadPath)) { New-Item -ItemType Directory -Path $downloadPath }
 $latestRelease = Get-LatestRelease
 if (-not $latestRelease) { Write-Error "Could not retrieve the latest release. Exiting."; return; }
 
@@ -125,8 +126,10 @@ if ($depsZipUrl) {
 
     # Remove existing Dependencies folder and expand the zip
     if (Test-Path $topDepsFolder) { Remove-Item -Path $topDepsFolder -Recurse -Force }
-   
-    Expand-Archive -LiteralPath $depsZipPath -DestinationPath $topDepsFolder -Force
+
+    # Replaces Expand archives with .NET System.IO.Compression
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($depsZipPath, $topDepsFolder)
 } 
 else { Write-Warning "No $depsZipName found in $latestTag, skipping dependency download."; }
 
@@ -156,4 +159,3 @@ if ($removeMsStoreAsSource.IsPresent) {
     # Automatically accept source agreements to avoid prompts. Mostly applies to msstore.
     winget list --accept-source-agreements | Out-Null
 }
-


### PR DESCRIPTION
Hi, @ThioJoe 

I encountered an issue while running `Install-Winget.ps1` in a **Windows Sandbox** using a non-English locale (specifically `de-DE`). The script fails during the dependency extraction phase after downloading the necessary assets.

### The Problem
The provided error log reveals that the command `Expand-Archive` failed because it could not find the Windows PowerShell data file `ArchiveResources.psd1`. This occurs because Windows Sandbox uses a minimal OS image that often lacks the localization files required by the `Microsoft.PowerShell.Archive` module.

### The Solution
I have updated the script to use the native .NET `System.IO.Compression.ZipFile` class instead of the standard PowerShell cmdlet.

### Why this is better for the Sandbox
* **Zero Dependencies**: It does not rely on the `Microsoft.PowerShell.Archive` module or its specific localization resources.
* **Native Reliability**: It utilizes the .NET framework, which is natively integrated and functional within the Sandbox environment.
* **Improved Robustness**: I added a check to ensure the `$downloadPath` exists before the script attempts to download `Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle` and other dependencies.

This change ensures that Winget can be installed reliably regardless of the host system's language settings.